### PR TITLE
Fix field type detection bug in update_project_item_field (fixes #9)

### DIFF
--- a/analysis.md
+++ b/analysis.md
@@ -1,0 +1,82 @@
+# Analysis of `update_project_item_field` Bug
+
+This document provides an analysis of the bug affecting the `update_project_item_field` tool and outlines a proposed solution.
+
+## 1. Root Cause Analysis
+
+The root cause of the bug lies in the `update_project_item_field` function within `src/github_projects_mcp/github_client.py`. The current implementation attempts to determine the data type of a project field by using a heuristic based on the prefix of the `field_id`.
+
+Specifically, the code contains the following logic:
+
+```python
+# src/github_projects_mcp/github_client.py
+
+if field_id.startswith("PVTSSF_"):  # Single Select Field
+    field_value_input = {"singleSelectOptionId": value}
+elif field_id.startswith("PVTF_"):  # Text Field (assumed prefix)
+    field_value_input = {"text": str(value)}
+elif field_id.startswith("PVTDF_"):  # Date Field (assumed prefix)
+    field_value_input = {"date": value}
+elif field_id.startswith("PVTNU_"):  # Number Field (assumed prefix)
+    field_value_input = {"number": float(value)}
+else:  # Default to text if type unknown
+    field_value_input = {"text": str(value)}
+```
+
+This approach is unreliable because the field ID prefixes are not guaranteed to correspond to the field's data type. As revealed in the bug report, the "Story Points" (Number) and "Start Date" (Date) fields both have IDs starting with `PVTF_`, which the code incorrectly assumes is always a "Text" field.
+
+When the tool attempts to update a "Number" or "Date" field, it constructs the GraphQL mutation with a `{ "text": "..." }` payload, which is invalid for those field types, causing the GitHub API to return an error.
+
+The `update_project_item_field` tool in `src/github_projects_mcp/server.py` also contributes to the problem by performing only basic type inference on the `field_value` before passing it to the `github_client`.
+
+## 2. Proposed Solution
+
+To fix this bug, the system must be updated to reliably determine the correct data type for a given field before constructing the GraphQL mutation. The guessing logic based on ID prefixes must be replaced with a more robust mechanism.
+
+The proposed solution involves the following steps:
+
+1.  **Enhance Field Discovery:** The `get_project_fields_details` function in `github_client.py` currently retrieves the `__typename` for each field. However, for fields of type `ProjectV2Field`, it does not differentiate between "Text", "Number", and "Date". The GraphQL query within this function needs to be updated to fetch the `dataType` for each field.
+
+    The updated query should look like this:
+
+    ```graphql
+    query GetProjectFields($projectId: ID!) {
+      node(id: $projectId) {
+        ... on ProjectV2 {
+          fields(first: 50) {
+            nodes {
+              ... on ProjectV2Field { id name __typename dataType } # <-- Add dataType
+              ... on ProjectV2IterationField {
+                 id name __typename
+                 configuration { iterations { id title startDate duration } }
+              }
+              ... on ProjectV2SingleSelectField {
+                 id name __typename
+                 options { id name color description }
+              }
+            }
+          }
+        }
+      }
+    }
+    ```
+
+2.  **Refactor `update_project_item_field`:** The `update_project_item_field` function in `github_client.py` must be refactored to:
+    a.  Call `get_project_fields_details` to get the complete details for all fields in the project.
+    b.  Find the specific field being updated using the `field_id`.
+    c.  Use the `dataType` and `__typename` from the field details to determine the correct structure for the `ProjectV2FieldValue` input object.
+    d.  Construct the GraphQL mutation with the correctly typed value (e.g., `{"number": 64}` or `{"date": "2025-08-11"}`).
+
+3.  **Improve Value Parsing:** The `update_project_item_field` tool in `server.py` should be updated to intelligently parse the incoming `field_value` string based on the determined data type. For example, it should convert the value to a `float` if the field type is "NUMBER".
+
+## 3. Implementation Plan
+
+1.  **Modify `github_client.py`:**
+    - Update the GraphQL query in `get_project_fields_details` to include `dataType`.
+    - Modify the processing loop in `get_project_fields_details` to store the `dataType`.
+    - Rewrite the `update_project_item_field` function to fetch field details and build the mutation payload based on the actual `dataType`.
+
+2.  **Modify `server.py`:**
+    - Update the `update_project_item_field` tool to perform type conversion on `field_value` based on the field's type before calling the `github_client`. This may involve a preliminary call to a function that can determine the field type by its ID.
+
+This approach will eliminate the unreliable guesswork and ensure that the GraphQL mutations are always constructed with the correct data types, resolving the bug for "Number" and "Date" fields while maintaining functionality for "SingleSelect" and other field types.

--- a/github-projects-mcp-issue.md
+++ b/github-projects-mcp-issue.md
@@ -1,0 +1,123 @@
+# Bug Report: `update_project_item_field` Fails for 'Number' and 'Date' Fields
+
+This document outlines a bug in the `update_project_item_field` tool where it fails to update custom fields of type 'Number' and 'Date' in a GitHub Project.
+
+## 1. Problem Description
+
+The `update_project_item_field` tool consistently fails when attempting to update the values of custom fields with the types 'Number' and 'Date'. The tool successfully updates fields of type 'SingleSelect', but any attempt to update the other two types results in a generic error: `Error: Could not update field value. Details: Failed to update field value for item ...`.
+
+This prevents the automation of key project management data, such as setting story points and start/target dates for project items.
+
+## 2. Project Context for Testing
+
+This section provides all the necessary details to reproduce and test the issue using a real-world project setup.
+
+### Project Details
+
+```json
+{
+  "id": "PVT_kwHOAAW1i84BADGg",
+  "number": 3,
+  "title": "BranchChat: Development",
+  "owner": "mweichert",
+  "url": "https://github.com/users/mweichert/projects/3"
+}
+```
+
+### Test Item (Issue #1)
+
+- **Issue Number:** 1
+- **Repository:** `mweichert/BranchChat`
+- **Item ID:** `PVTI_lAHOAAW1i84BADGgzgdd8ew`
+
+### Custom Field Definitions
+
+```json
+[
+  {
+    "name": "Story Points",
+    "id": "PVTF_lAHOAAW1i84BADGgzgy-kZs",
+    "type": "ProjectV2Field" 
+  },
+  {
+    "name": "Start Date",
+    "id": "PVTF_lAHOAAW1i84BADGgzgy-JI8",
+    "type": "ProjectV2Field"
+  },
+  {
+    "name": "Target Date",
+    "id": "PVTF_lAHOAAW1i84BADGgzgy-JLg",
+    "type": "ProjectV2Field"
+  },
+  {
+    "name": "Priority",
+    "id": "PVTSSF_lAHOAAW1i84BADGgzgy-JI4",
+    "type": "ProjectV2SingleSelectField",
+    "options": [
+      { "name": "Critical", "id": "06b11da1" }
+    ]
+  }
+]
+```
+
+## 3. Summary of Failed Attempts
+
+The following is a log of the different `field_value` formats that have been attempted and have failed for the 'Number' and 'Date' field types.
+
+### For "Story Points" (Number Field)
+
+- **As a string:** `"64"`
+- **As a number:** `64` (This resulted in an unparsable response from the tool)
+
+### For "Start Date" and "Target Date" (Date Fields)
+
+- **YYYY-MM-DD:** `"2025-08-11"`
+- **ISO 8601 Timestamp:** `"2025-08-11T00:00:00Z"`
+- **Unix Timestamp:** `"1754892800"`
+- **Human-readable string:** `"Aug 11, 2025"`
+
+## 4. Proposed Testing Plan
+
+This plan outlines the steps to reproduce the bug and verify the fix.
+
+### Step 1: Reproduce the Bug
+
+1.  **Target the "Story Points" field.**
+    - Execute the `update_project_item_field` tool with the following parameters:
+      - `owner`: `"mweichert"`
+      - `project_number`: `3`
+      - `item_id`: `"PVTI_lAHOAAW1i84BADGgzgdd8ew"`
+      - `field_id`: `"PVTF_lAHOAAW1i84BADGgzgy-kZs"`
+      - `field_value`: `"64"`
+    - **Expected Result:** The tool should return an error.
+
+2.  **Target the "Start Date" field.**
+    - Execute the `update_project_item_field` tool with the following parameters:
+      - `owner`: `"mweichert"`
+      - `project_number`: `3`
+      - `item_id`: `"PVTI_lAHOAAW1i84BADGgzgdd8ew"`
+      - `field_id`: `"PVTF_lAHOAAW1i84BADGgzgy-JI8"`
+      - `field_value`: `"2025-08-11"`
+    - **Expected Result:** The tool should return an error.
+
+### Step 2: Test the Fix
+
+After implementing a potential fix in the `github-projects-mcp` codebase, the following tests should be run.
+
+1.  **Test the "Story Points" field.**
+    - Execute the same command as in Step 1.1.
+    - **Expected Result:** The tool should succeed and return a confirmation message. The "Story Points" field for issue #1 in the "BranchChat: Development" project should be updated to `64`.
+
+2.  **Test the "Start Date" field.**
+    - Execute the same command as in Step 1.2.
+    - **Expected Result:** The tool should succeed. The "Start Date" field for issue #1 should be updated to `2025-08-11`.
+
+3.  **Test the "Target Date" field.**
+    - Execute the `update_project_item_field` tool with `field_id`: `"PVTF_lAHOAAW1i84BADGgzgy-JLg"` and `field_value`: `"2025-09-19"`.
+    - **Expected Result:** The tool should succeed. The "Target Date" field for issue #1 should be updated to `2025-09-19`.
+
+4.  **Verify SingleSelect Fields Still Work.**
+    - Execute the `update_project_item_field` tool to update the "Priority" field:
+      - `field_id`: `"PVTSSF_lAHOAAW1i84BADGgzgy-JI4"`
+      - `field_value`: `"06b11da1"` (ID for "Critical")
+    - **Expected Result:** The tool should succeed, confirming that the fix did not break existing functionality.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,5 +23,11 @@ allow-direct-references = true
 [tool.hatch.build.targets.wheel]
 packages = ["src/github_projects_mcp"]
 
+[dependency-groups]
+dev = [
+    "pytest>=8.4.1",
+    "pytest-asyncio>=1.1.0",
+]
+
 [project.scripts]
 mcp-github-projects = "github_projects_mcp.server:main"

--- a/src/github_projects_mcp/github_client.py
+++ b/src/github_projects_mcp/github_client.py
@@ -311,7 +311,7 @@ class GitHubClient:
             ... on ProjectV2 {
               fields(first: 50) {
                 nodes {
-                  ... on ProjectV2Field { id name __typename }
+                  ... on ProjectV2Field { id name __typename dataType }
                   ... on ProjectV2IterationField {
                      id name __typename
                      configuration { iterations { id title startDate duration } }
@@ -364,6 +364,7 @@ class GitHubClient:
                     field_details_map[field_name] = {
                         "id": field.get("id"),
                         "type": field.get("__typename"),
+                        "dataType": field.get("dataType"),  # Add dataType for ProjectV2Field
                         "options": options_map,  # Map Name -> ID
                         "iterations": iterations_map,
                     }
@@ -1010,50 +1011,79 @@ class GitHubClient:
             logger.error(f"Cannot update item field: {e}")
             raise
 
-        # Prepare value based on its type and field ID convention
-        # This mapping might need refinement based on actual field types fetched separately
+        # Get field details to determine the correct field type
+        try:
+            field_details = await self.get_project_fields_details(owner, project_number)
+        except GitHubClientError as e:
+            logger.error(f"Cannot get field details for field type detection: {e}")
+            raise
+
+        # Find the field by ID
+        target_field = None
+        for field_name, details in field_details.items():
+            if details.get("id") == field_id:
+                target_field = details
+                break
+
+        if not target_field:
+            raise GitHubClientError(f"Field with ID {field_id} not found in project")
+
+        field_type = target_field.get("type")
+        data_type = target_field.get("dataType")
+        
+        logger.debug(f"Field ID: {field_id}, Type: {field_type}, DataType: {data_type}")
+
+        # Prepare value based on actual field type and dataType
         field_value_input: Dict[str, Any] = {}
 
-        # Heuristic based on ID prefix - A better approach would be to fetch field type first
-        if field_id.startswith("PVTSSF_"):  # Single Select Field (assumed prefix)
+        if field_type == "ProjectV2SingleSelectField":
             if isinstance(value, str):
                 field_value_input = {"singleSelectOptionId": value}
             else:
                 raise GitHubClientError(
                     f"Invalid value type for single select field {field_id}. Expected option ID string."
                 )
-        elif field_id.startswith("PVTIF_"):  # Iteration Field (assumed prefix)
+        elif field_type == "ProjectV2IterationField":
             if isinstance(value, str):
                 field_value_input = {"iterationId": value}
             else:
                 raise GitHubClientError(
                     f"Invalid value type for iteration field {field_id}. Expected iteration ID string."
                 )
-        # Add more field types based on prefixes or fetched field info
-        elif field_id.startswith("PVTF_"):  # Text Field (assumed prefix)
-            if isinstance(value, str):
-                field_value_input = {"text": value}
-            else:  # Attempt to convert
+        elif field_type == "ProjectV2Field":
+            # For ProjectV2Field, use dataType to determine the correct value format
+            if data_type == "TEXT":
                 field_value_input = {"text": str(value)}
-        elif field_id.startswith("PVTDF_"):  # Date Field (assumed prefix)
-            if isinstance(value, str):  # Assuming date string like YYYY-MM-DD
-                field_value_input = {"date": value}
+            elif data_type == "NUMBER":
+                try:
+                    # Convert string numbers to float for GraphQL
+                    if isinstance(value, str):
+                        field_value_input = {"number": float(value)}
+                    elif isinstance(value, (int, float)):
+                        field_value_input = {"number": float(value)}
+                    else:
+                        raise ValueError(f"Cannot convert {value} to number")
+                except (ValueError, TypeError) as e:
+                    raise GitHubClientError(
+                        f"Invalid value for number field {field_id}: {value}. Error: {e}"
+                    )
+            elif data_type == "DATE":
+                if isinstance(value, str):
+                    field_value_input = {"date": value}
+                else:
+                    raise GitHubClientError(
+                        f"Invalid value type for date field {field_id}. Expected date string (YYYY-MM-DD)."
+                    )
             else:
-                raise GitHubClientError(
-                    f"Invalid value type for date field {field_id}. Expected date string (YYYY-MM-DD)."
+                # Unknown dataType, default to text
+                logger.warning(
+                    f"Unknown dataType '{data_type}' for ProjectV2Field {field_id}. Defaulting to text."
                 )
-        elif field_id.startswith("PVTNU_"):  # Number Field (assumed prefix)
-            if isinstance(value, (int, float)):
-                field_value_input = {
-                    "number": float(value)
-                }  # GraphQL uses Float for numbers
-            else:
-                raise GitHubClientError(
-                    f"Invalid value type for number field {field_id}. Expected int or float."
-                )
-        else:  # Default to text if type unknown
+                field_value_input = {"text": str(value)}
+        else:
+            # Unknown field type, default to text
             logger.warning(
-                f"Unknown field type for {field_id}. Attempting to set as text."
+                f"Unknown field type '{field_type}' for {field_id}. Defaulting to text."
             )
             field_value_input = {"text": str(value)}
 

--- a/test_simple_bug_demo.py
+++ b/test_simple_bug_demo.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Simple demonstration of the field update bug.
+
+This script shows how the current field type detection logic fails
+for Number and Date fields that have PVTF_ prefixes.
+"""
+
+def demonstrate_field_type_detection_bug():
+    """
+    Demonstrates the core bug in field type detection logic.
+    
+    The issue is in github_client.py lines 1017-1058 where field types
+    are determined by ID prefixes, but the real-world data shows that
+    Number and Date fields can also have PVTF_ prefixes.
+    """
+    
+    print("=== Demonstrating Field Type Detection Bug ===\n")
+    
+    # Real field data from github-projects-mcp-issue.md
+    test_fields = [
+        {
+            "name": "Story Points",
+            "id": "PVTF_lAHOAAW1i84BADGgzgy-kZs",
+            "actual_type": "Number",
+            "test_value": "64"
+        },
+        {
+            "name": "Start Date", 
+            "id": "PVTF_lAHOAAW1i84BADGgzgy-JI8",
+            "actual_type": "Date",
+            "test_value": "2025-08-11"
+        },
+        {
+            "name": "Priority",
+            "id": "PVTSSF_lAHOAAW1i84BADGgzgy-JI4", 
+            "actual_type": "SingleSelect",
+            "test_value": "06b11da1"
+        }
+    ]
+    
+    print("Current buggy logic in update_project_item_field:")
+    print("=" * 50)
+    
+    for field in test_fields:
+        field_id = field["id"]
+        actual_type = field["actual_type"]
+        test_value = field["test_value"]
+        
+        # Replicate the buggy logic from github_client.py:1017-1058
+        if field_id.startswith("PVTSSF_"):  # Single Select Field
+            detected_type = "SingleSelect"
+            field_value_input = {"singleSelectOptionId": test_value}
+        elif field_id.startswith("PVTF_"):  # Text Field (WRONG ASSUMPTION!)
+            detected_type = "Text"
+            field_value_input = {"text": str(test_value)}
+        elif field_id.startswith("PVTDF_"):  # Date Field
+            detected_type = "Date" 
+            field_value_input = {"date": test_value}
+        elif field_id.startswith("PVTNU_"):  # Number Field
+            detected_type = "Number"
+            field_value_input = {"number": float(test_value)}
+        else:
+            detected_type = "Text (default)"
+            field_value_input = {"text": str(test_value)}
+        
+        status = "✅ CORRECT" if detected_type.split()[0] == actual_type else "❌ WRONG"
+        
+        print(f"Field: {field['name']}")
+        print(f"  ID: {field_id}")
+        print(f"  Actual Type: {actual_type}")
+        print(f"  Detected Type: {detected_type}")
+        print(f"  Generated Input: {field_value_input}")
+        print(f"  Status: {status}")
+        
+        if "WRONG" in status:
+            if actual_type == "Number":
+                correct_input = {"number": float(test_value)}
+                print(f"  Should be: {correct_input}")
+            elif actual_type == "Date":
+                correct_input = {"date": test_value}
+                print(f"  Should be: {correct_input}")
+        print()
+    
+    print("Root Cause:")
+    print("=" * 50) 
+    print("The bug occurs because the code assumes that field ID prefixes")
+    print("reliably indicate field types, but this is not true in practice.")
+    print("Both 'Story Points' (Number) and 'Start Date' (Date) fields")
+    print("have IDs starting with 'PVTF_', causing them to be incorrectly")
+    print("treated as Text fields.")
+    print()
+    print("This results in GraphQL mutations with wrong field value types:")
+    print("- Number fields get {\"text\": \"64\"} instead of {\"number\": 64.0}")
+    print("- Date fields get {\"text\": \"2025-08-11\"} instead of {\"date\": \"2025-08-11\"}")
+    print()
+    print("The fix requires fetching actual field types from the GraphQL API")
+    print("rather than guessing based on ID prefixes.")
+
+if __name__ == "__main__":
+    demonstrate_field_type_detection_bug()

--- a/test_simple_fix.py
+++ b/test_simple_fix.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Simple test to verify the fix works by inspecting the actual call structure.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+from src.github_projects_mcp.github_client import GitHubClient
+
+
+async def test_fix_works():
+    """Verify the fix generates correct field value inputs."""
+    client = GitHubClient(token="fake_token")
+    
+    # Mock field details with correct types
+    mock_field_details = {
+        "Story Points": {
+            "id": "PVTF_lAHOAAW1i84BADGgzgy-kZs",
+            "type": "ProjectV2Field",
+            "dataType": "NUMBER",
+            "options": {},
+            "iterations": {}
+        },
+        "Start Date": {
+            "id": "PVTF_lAHOAAW1i84BADGgzgy-JI8",
+            "type": "ProjectV2Field", 
+            "dataType": "DATE",
+            "options": {},
+            "iterations": {}
+        },
+        "Priority": {
+            "id": "PVTSSF_lAHOAAW1i84BADGgzgy-JI4",
+            "type": "ProjectV2SingleSelectField",
+            "dataType": None,
+            "options": {"Critical": "06b11da1"},
+            "iterations": {}
+        }
+    }
+    
+    with patch.object(client, 'get_project_node_id', return_value="PVT_kwHOAAW1i84BADGg"), \
+         patch.object(client, 'get_project_fields_details', return_value=mock_field_details), \
+         patch.object(client, 'execute_query', return_value={"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "test"}}}) as mock_execute:
+        
+        print("Testing Number field...")
+        await client.update_project_item_field(
+            owner="mweichert",
+            project_number=3,
+            item_id="PVTI_lAHOAAW1i84BADGgzgdd8ew",
+            field_id="PVTF_lAHOAAW1i84BADGgzgy-kZs",  # Story Points
+            value="64"
+        )
+        
+        # Check the mutation call
+        calls = mock_execute.call_args_list
+        print(f"All calls: {calls}")
+        mutation_call = calls[-1]  # Last call should be the mutation
+        print(f"Mutation call structure: {mutation_call}")
+        print(f"Call args: {mutation_call[0] if mutation_call else 'None'}")
+        print(f"Call kwargs: {mutation_call[1] if len(mutation_call) > 1 else 'None'}")
+        
+        # Access the variables from the call arguments
+        # The call structure is call(query_string, variables_dict)
+        variables = mutation_call.args[1] if len(mutation_call.args) > 1 else {}
+        
+        print(f"Number field value: {variables.get('value')}")
+        assert variables.get('value') == {"number": 64.0}, f"Expected number field but got {variables.get('value')}"
+        print("✅ Number field correctly generates {'number': 64.0}")
+        
+        # Reset mock
+        mock_execute.reset_mock()
+        
+        print("\nTesting Date field...")
+        await client.update_project_item_field(
+            owner="mweichert",
+            project_number=3,
+            item_id="PVTI_lAHOAAW1i84BADGgzgdd8ew",
+            field_id="PVTF_lAHOAAW1i84BADGgzgy-JI8",  # Start Date
+            value="2025-08-11"
+        )
+        
+        calls = mock_execute.call_args_list
+        mutation_call = calls[-1]
+        variables = mutation_call.args[1] if len(mutation_call.args) > 1 else {}
+        
+        print(f"Date field value: {variables.get('value')}")
+        assert variables.get('value') == {"date": "2025-08-11"}, f"Expected date field but got {variables.get('value')}"
+        print("✅ Date field correctly generates {'date': '2025-08-11'}")
+        
+        # Reset mock
+        mock_execute.reset_mock()
+        
+        print("\nTesting SingleSelect field...")
+        await client.update_project_item_field(
+            owner="mweichert", 
+            project_number=3,
+            item_id="PVTI_lAHOAAW1i84BADGgzgdd8ew",
+            field_id="PVTSSF_lAHOAAW1i84BADGgzgy-JI4",  # Priority
+            value="06b11da1"
+        )
+        
+        calls = mock_execute.call_args_list
+        mutation_call = calls[-1]
+        variables = mutation_call.args[1] if len(mutation_call.args) > 1 else {}
+        
+        print(f"SingleSelect field value: {variables.get('value')}")
+        assert variables.get('value') == {"singleSelectOptionId": "06b11da1"}, f"Expected single select field but got {variables.get('value')}"
+        print("✅ SingleSelect field correctly generates {'singleSelectOptionId': '06b11da1'}")
+
+
+if __name__ == "__main__":
+    print("=== Testing the Bug Fix ===\n")
+    asyncio.run(test_fix_works())
+    print("\n🎉 All tests passed! The fix is working correctly.")


### PR DESCRIPTION
## Problem
The `update_project_item_field` function failed when updating Number and Date fields in GitHub Projects V2. The root cause was incorrect field type detection logic that relied on unreliable field ID prefixes.

### Issues Found:
- Number fields (e.g., "Story Points") with ID `PVTF_lAHOAAW1i84BADGgzgy-kZs` were incorrectly treated as Text fields
- Date fields (e.g., "Start Date") with ID `PVTF_lAHOAAW1i84BADGgzgy-JI8` were also incorrectly treated as Text fields
- Both field types have IDs starting with `PVTF_`, but the code assumed this prefix always indicated Text fields
- This caused GraphQL mutations with wrong field value types:
  - Number fields got `{"text": "64"}` instead of `{"number": 64.0}`
  - Date fields got `{"text": "2025-08-11"}` instead of `{"date": "2025-08-11"}`

## Solution
Replaced unreliable ID prefix guessing with actual field metadata lookup from GitHub's GraphQL API.

### Key Changes:
1. **Enhanced GraphQL query**: Added `dataType` field to `get_project_fields_details` query
2. **Improved field metadata**: Store `dataType` alongside existing field information
3. **Robust type detection**: Use actual field `type` and `dataType` instead of ID prefixes:
   - `ProjectV2Field` with `dataType: "NUMBER"` → `{"number": float(value)}`
   - `ProjectV2Field` with `dataType: "DATE"` → `{"date": value}`
   - `ProjectV2Field` with `dataType: "TEXT"` → `{"text": str(value)}`
   - `ProjectV2SingleSelectField` → `{"singleSelectOptionId": value}`

### Files Modified:
- `src/github_projects_mcp/github_client.py`: Core fix implementation
- `pyproject.toml`: Added dev dependencies for testing

### Test Files Added:
- `test_simple_bug_demo.py`: Demonstrates the original bug
- `test_simple_fix.py`: Verifies the fix works correctly
- `analysis.md`: Detailed root cause analysis and implementation plan
- `github-projects-mcp-issue.md`: Bug report with reproduction steps

## Testing
- ✅ Number fields now correctly generate `{"number": 64.0}`
- ✅ Date fields now correctly generate `{"date": "2025-08-11"}`
- ✅ SingleSelect fields continue to work as before
- ✅ Comprehensive error handling for invalid field values
- ✅ Backward compatibility maintained

This fix enables reliable updates of all GitHub Projects V2 field types without depending on unreliable heuristics and fixes #9 